### PR TITLE
Ability to set a different target directory when generating configs

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -29,6 +29,10 @@ enum Commands {
         /// Number of clickhouse replicas
         #[arg(long)]
         num_replicas: u64,
+
+        /// Target directory where all configuration files will be saved
+        #[arg(short, long)]
+        target_dir: Option<Utf8PathBuf>,
     },
 
     /// Launch our deployment given generated configs
@@ -36,6 +40,10 @@ enum Commands {
         /// Root path of all configuration
         #[arg(short, long)]
         path: Utf8PathBuf,
+
+        /// Target directory where all configuration files will be saved
+        #[arg(short, long)]
+        target_dir: Option<Utf8PathBuf>,
     },
 
     /// Stop all our deployed processes
@@ -43,6 +51,10 @@ enum Commands {
         /// Root path of all configuration
         #[arg(short, long)]
         path: Utf8PathBuf,
+
+        /// Target directory where all configuration files will be saved
+        #[arg(short, long)]
+        target_dir: Option<Utf8PathBuf>,
     },
 
     /// Show metadata about the deployment
@@ -50,6 +62,10 @@ enum Commands {
         /// Root path of all configuration
         #[arg(short, long)]
         path: Utf8PathBuf,
+
+        /// Target directory where all configuration files will be saved
+        #[arg(short, long)]
+        target_dir: Option<Utf8PathBuf>,
     },
 
     /// Add a keeper node to the keeper cluster
@@ -57,6 +73,10 @@ enum Commands {
         /// Root path of all configuration
         #[arg(short, long)]
         path: Utf8PathBuf,
+
+        /// Target directory where all configuration files will be saved
+        #[arg(short, long)]
+        target_dir: Option<Utf8PathBuf>,
     },
 
     /// Remove a keeper node
@@ -68,6 +88,10 @@ enum Commands {
         /// Id of the keeper node to remove
         #[arg(long)]
         id: u64,
+
+        /// Target directory where all configuration files will be saved
+        #[arg(short, long)]
+        target_dir: Option<Utf8PathBuf>,
     },
 
     /// Get the keeper config from a given keeper
@@ -82,6 +106,10 @@ enum Commands {
         /// Root path of all configuration
         #[arg(short, long)]
         path: Utf8PathBuf,
+
+        /// Target directory where all configuration files will be saved
+        #[arg(short, long)]
+        target_dir: Option<Utf8PathBuf>,
     },
 
     /// Remove a clickhouse server
@@ -93,6 +121,10 @@ enum Commands {
         /// Id of the clickhouse server node to remove
         #[arg(long)]
         id: u64,
+
+        /// Target directory where all configuration files will be saved
+        #[arg(short, long)]
+        target_dir: Option<Utf8PathBuf>,
     },
 }
 
@@ -109,20 +141,28 @@ async fn main() {
 async fn handle() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Commands::GenConfig { path, num_keepers, num_replicas } => {
-            let mut d = Deployment::new_with_default_port_config(path, CLUSTER);
+        Commands::GenConfig { path, num_keepers, num_replicas, target_dir } => {
+            let mut d = Deployment::new_with_default_port_config(
+                path, CLUSTER, target_dir,
+            );
             d.generate_config(num_keepers, num_replicas)
         }
-        Commands::Deploy { path } => {
-            let d = Deployment::new_with_default_port_config(path, CLUSTER);
+        Commands::Deploy { path, target_dir } => {
+            let d = Deployment::new_with_default_port_config(
+                path, CLUSTER, target_dir,
+            );
             d.deploy()
         }
-        Commands::Teardown { path } => {
-            let d = Deployment::new_with_default_port_config(path, CLUSTER);
+        Commands::Teardown { path, target_dir } => {
+            let d = Deployment::new_with_default_port_config(
+                path, CLUSTER, target_dir,
+            );
             d.teardown()
         }
-        Commands::Show { path } => {
-            let d = Deployment::new_with_default_port_config(path, CLUSTER);
+        Commands::Show { path, target_dir } => {
+            let d = Deployment::new_with_default_port_config(
+                path, CLUSTER, target_dir,
+            );
             match &d.meta() {
                 Some(meta) => println!("{:#?}", meta),
                 None => println!(
@@ -131,31 +171,40 @@ async fn handle() -> anyhow::Result<()> {
             }
             Ok(())
         }
-        Commands::AddKeeper { path } => {
-            let mut d = Deployment::new_with_default_port_config(path, CLUSTER);
+        Commands::AddKeeper { path, target_dir } => {
+            let mut d = Deployment::new_with_default_port_config(
+                path, CLUSTER, target_dir,
+            );
             d.add_keeper()
         }
-        Commands::RemoveKeeper { path, id } => {
-            let mut d = Deployment::new_with_default_port_config(path, CLUSTER);
+        Commands::RemoveKeeper { path, id, target_dir } => {
+            let mut d = Deployment::new_with_default_port_config(
+                path, CLUSTER, target_dir,
+            );
             d.remove_keeper(id.into())
         }
         Commands::KeeperConfig { id } => {
             // Unused
             let dummy_path = ".".into();
-            let d =
-                Deployment::new_with_default_port_config(dummy_path, CLUSTER);
+            let d = Deployment::new_with_default_port_config(
+                dummy_path, CLUSTER, None,
+            );
             let addr = d.keeper_addr(id.into())?;
             let zk = KeeperClient::new(addr);
             let output = zk.config().await?;
             println!("{output:#?}");
             Ok(())
         }
-        Commands::AddServer { path } => {
-            let mut d = Deployment::new_with_default_port_config(path, CLUSTER);
+        Commands::AddServer { path, target_dir } => {
+            let mut d = Deployment::new_with_default_port_config(
+                path, CLUSTER, target_dir,
+            );
             d.add_server()
         }
-        Commands::RemoveServer { path, id } => {
-            let mut d = Deployment::new_with_default_port_config(path, CLUSTER);
+        Commands::RemoveServer { path, id, target_dir } => {
+            let mut d = Deployment::new_with_default_port_config(
+                path, CLUSTER, target_dir,
+            );
             d.remove_server(id.into())
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,13 @@ impl DeploymentConfig {
     pub fn new_with_default_ports<S: Into<String>>(
         path: Utf8PathBuf,
         cluster_name: S,
+        target_dir: Option<Utf8PathBuf>,
     ) -> DeploymentConfig {
-        let path = path.join(DEPLOYMENT_DIR);
+        let dir = match target_dir {
+            Some(d) => d,
+            None => Utf8PathBuf::from(DEPLOYMENT_DIR),
+        };
+        let path = path.join(dir);
         DeploymentConfig {
             path,
             base_ports: DEFAULT_BASE_PORTS,
@@ -196,9 +201,13 @@ impl Deployment {
     pub fn new_with_default_port_config<S: Into<String>>(
         path: Utf8PathBuf,
         cluster_name: S,
+        target_dir: Option<Utf8PathBuf>,
     ) -> Deployment {
-        let config =
-            DeploymentConfig::new_with_default_ports(path, cluster_name);
+        let config = DeploymentConfig::new_with_default_ports(
+            path,
+            cluster_name,
+            target_dir,
+        );
         Deployment::new(config)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,8 +588,9 @@ impl Deployment {
                 [self.config.path.as_str(), &format!("clickhouse-{id}")]
                     .iter()
                     .collect();
+            std::fs::create_dir_all(&dir)?;
+
             let logs: Utf8PathBuf = dir.join("logs");
-            std::fs::create_dir_all(&logs)?;
             let log = logs.join("clickhouse.log");
             let errorlog = logs.join("clickhouse.err.log");
             let data_path = dir.join("data");
@@ -643,8 +644,9 @@ impl Deployment {
             [self.config.path.as_str(), &format!("keeper-{this_keeper}")]
                 .iter()
                 .collect();
+        std::fs::create_dir_all(&dir)?;
+
         let logs: Utf8PathBuf = dir.join("logs");
-        std::fs::create_dir_all(&logs)?;
         let log = logs.join("clickhouse-keeper.log");
         let errorlog = logs.join("clickhouse-keeper.err.log");
         let config = KeeperConfig {


### PR DESCRIPTION
Related: https://github.com/oxidecomputer/clickward/issues/6 https://github.com/oxidecomputer/omicron/issues/5999

## Overview

New `--target-dir` flag to allow deployments to live in a directory of their choosing.

New functionality:

```console
$ cargo run gen-config --path . --num-keepers 3 --num-replicas 2 --target-dir testing
   Compiling clickward v0.1.0 (/Users/karcar/src/clickward)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.55s
     Running `target/debug/main gen-config --path . --num-keepers 3 --num-replicas 2 --target-dir testing`
$ tree testing
testing
├── clickhouse-1
│   └── clickhouse-config.xml
├── clickhouse-2
│   └── clickhouse-config.xml
├── clickward-metadata.json
├── keeper-1
│   └── keeper-config.xml
├── keeper-2
│   └── keeper-config.xml
└── keeper-3
    └── keeper-config.xml

6 directories, 6 files
$ cargo run deploy --path . --target-dir testing
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/main deploy --path . --target-dir testing`
Deploying keeper: ./testing/keeper-1
Deploying keeper: ./testing/keeper-3
Deploying keeper: ./testing/keeper-2
Deploying clickhouse server: ./testing/clickhouse-1
Deploying clickhouse server: ./testing/clickhouse-2
$ cargo run teardown --path . --target-dir testing
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/main teardown --path . --target-dir testing`
Stopping keeper: ./testing/keeper-1 at pid 43724
Stopping keeper: ./testing/keeper-2 at pid 43762
Stopping keeper: ./testing/keeper-3 at pid 43743
Stopping clickhouse server clickhouse-1: pid - 43781, child pid - 43802
Stopping clickhouse server clickhouse-2: pid - 43800, child pid - 43801
```

Retained old functionality as well:

```console
$ cargo run gen-config --path . --num-keepers 3 --num-replicas 2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/main gen-config --path . --num-keepers 3 --num-replicas 2`
$ tree deployment
deployment
├── clickhouse-1
│   └── clickhouse-config.xml
├── clickhouse-2
│   └── clickhouse-config.xml
├── clickward-metadata.json
├── keeper-1
│   └── keeper-config.xml
├── keeper-2
│   └── keeper-config.xml
└── keeper-3
    └── keeper-config.xml

6 directories, 6 files
$ cargo run deploy --path . 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/main deploy --path .`
Deploying keeper: ./deployment/keeper-1
Deploying keeper: ./deployment/keeper-3
Deploying keeper: ./deployment/keeper-2
Deploying clickhouse server: ./deployment/clickhouse-1
Deploying clickhouse server: ./deployment/clickhouse-2
$ cargo run teardown --path .
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/main teardown --path .`
Stopping keeper: ./deployment/keeper-1 at pid 43988
Stopping keeper: ./deployment/keeper-2 at pid 44026
Stopping keeper: ./deployment/keeper-3 at pid 44007
Stopping clickhouse server clickhouse-1: pid - 44045, child pid - 44065
Stopping clickhouse server clickhouse-2: pid - 44064, child pid - 44066
```

## Why do we need this?

- In production environments, we'll need the ability to set the name of the directory where the configuration files will live.
- In testing environments, users may want to have several configurations living side by side to iterate.

## Caveats

I've tried to keep as much old functionality there as possible. The flags and code may look neater if I get rid of a default directory name altogether, but it would lose a bit of the simplicity. Happy to change this if it doesn't make sense

