### PR TITLE
Add support for opentelemetry_span_log

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,7 @@ impl ReplicaConfig {
 
     <profiles>
         <default>
+            <opentelemetry_start_trace_probability>1</opentelemetry_start_trace_probability>
             <load_balancing>random</load_balancing>
         </default>
 
@@ -118,6 +119,23 @@ impl ReplicaConfig {
 {macros}
 {remote_servers}
 {keepers}
+
+    <!-- 
+        In newer versions of ClickHouse this table is created automatically.
+        We should remove this block once we update to a newer version of 
+        ClickHouse that does not need the system.opentelemetry_span_log
+        table to be created via the config.xml file
+    -->
+    <opentelemetry_span_log>
+        <engine>
+            engine MergeTree
+            partition by toYYYYMM(finish_date)
+            order by (finish_date, finish_time_us, trace_id)
+        </engine>
+        <database>system</database>
+        <table>opentelemetry_span_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </opentelemetry_span_log>
 
 </clickhouse>
 "


### PR DESCRIPTION
As part of the work to add long running tests clickhouse tests to our rack. The ability to retrieve information about trace spans for each query is pretty useful https://clickhouse.com/docs/en/operations/opentelemetry#tracing-the-clickhouse-itself

Tested locally:

```console
SELECT *
FROM system.opentelemetry_span_log
LIMIT 1
FORMAT Vertical

Query id: 69a63442-dd2e-4a78-988e-3295dbf8c772

Row 1:
──────
trace_id:       2da282c8-ee5b-df09-bafb-d97070ebd260
span_id:        2153580869789539949
parent_span_id: 17995451838162395680
operation_name: DB::InterpreterSelectWithUnionQuery::execute()
kind:           INTERNAL
start_time_us:  1731545566056513
finish_time_us: 1731545566056775
finish_date:    2024-11-14
attribute:      {'clickhouse.thread_id':'6628494'}

1 row in set. Elapsed: 0.004 sec.
```

I'm integrating here first as I'm testing things locally for now, will update omicron later